### PR TITLE
Update reverse.sh

### DIFF
--- a/reverse.sh
+++ b/reverse.sh
@@ -1,31 +1,63 @@
 #!/bin/bash
 
-#######################
-#Check for requirments#
-#######################
-zenity=$(which zenity)
-if [ "$zenity" == "" ]; then
-    echo "You must have zenity installed"
-    exit 1
-fi
-#avconv=$(which avconv)
-#if [ "$avconv" == ""]; then
-#    zenity --error --text="You must have avconv installed"
-#    exit 1 
+########################
+#Check for requirements#
+########################
+#zenity=$(which zenity)
+#if [ "$zenity" == "" ]; then
+#    echo "You must have zenity installed"
+#    exit 1
 #fi
 
-ffmpeg=$(which ffmpeg)
-if [ "$ffmpeg" == "" ]; then
-	echo "You must have ffmpeg installed"
-	exit 1
+# Check if avconv in installed, fallback to ffmpeg (avconv's previous name, still used on some systems)
+
+avconv=$(which avconv)
+if [ "$avconv" == "" ]; then
+	avconv=$(which ffmpeg)
 fi
+
+if [ "$avconv" == "" ]; then
+#    zenity --error --text="You must have avconv installed"
+    echo "You must have either avconv or ffmpeg installed."
+    exit 1 
+fi
+
+##############################
+#Check command line arguments#
+##############################
+
+if [ -z $1 ]; then
+    echo "No input file supplied."
+    exit 1
+fi
+
+if [ ! -e $1 ]; then
+    echo "File $1 does not exist."
+    exit 1
+fi
+
+if [ -z $2 ]; then
+    output_file='reversed_'$1
+else
+    output_file=$2
+fi
+
+if [ -e $output_file ]; then
+    echo "File $output_file already exists."
+    exit 1
+fi
+
+#ffmpeg=$(which ffmpeg)
+#if [ "$ffmpeg" == "" ]; then
+#	echo "You must have ffmpeg installed"
+#	exit 1
+#fi
 ##################################
 #Spawn frames into images/ folder#
 ##################################
 mkdir images
 cd images
-#avconv -i ../$1 %d.jpg
-ffmpeg -i ../$1 %d.jpg
+$avconv -i ../$1 %d.jpg
 
 ##############
 #Count images#
@@ -42,19 +74,20 @@ i=1
 factor=0
 while [ $factor -lt $images ]; do
     new_name=$((images-factor))
-    echo $new_name
+    printf $new_name' '
     mv $i.jpg image$new_name.jpg
     let factor=factor+1
     let i=i+1
 done
+echo ''
+
 ###############################################
 #Finally convert newly named images into video#
 ###############################################
-#avconv -f image2 -i image%d.jpg -vcodec mpeg4 ../$2
-ffmpeg -f image2 -i image%d.jpg -vcodec mpeg4 ../$2
-
+#$avconv -f image2 -i image%d.jpg -vcodec mjpeg -b 12000k -r 30 ../$output_file
+$avconv -f image2 -i image%d.jpg -vcodec mpeg4 ../$output_file
 
 #######################
 #Remove temporal files#
 #######################
-rm *.jpg
+rm *jpg


### PR DESCRIPTION
I have done some improvements:
- Removed dependency for zenity: It was merely used to tell the user if ffmpeg/avconv weren't installed. A further improvement could be to check whether zenity is installed and then either use "echo" or zenity. However, using zenity makes it problematic in scripts (i.e., if reverse.sh would be called from another script) anyway, so it's better to not use it in that case.
- Check if either ffmpeg or avconv in installed and use what was found.
- Check if input file exists.
- Check if name of output file is supplied; if not, use "reversed_" + input file name as default.
- Instead of writing the number of the renamed picture in an own line, separate the names with spaces (results in using less screen height).
  Improvements to think about:
- The quality of the output video is poor. I have done some experiments with different bit rates, frame rates, and formats, but to no avail.
- If avconv isn't installed, ask user if (s)he wants to install it (detect OS (use apt-get on Debian & friends, yum on RH/Suse and others that use RPM, pkgin/pkg_add on *BSD, etc.), detect if running as root or not to put "sudo" in front of installation command (and check before, if non-root user is in wheel group).
